### PR TITLE
Add enum for different possible LS_COLORS entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 
     # Minimum Rust supported channel.
     - os: linux
-      rust: 1.31.0
+      rust: 1.32.0
       env: TARGET=x86_64-unknown-linux-gnu
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,4 +449,17 @@ mod tests {
         let style = get_default_style(tmp_symlink_path).unwrap();
         assert_eq!(Some(Color::Red), style.foreground);
     }
+
+    #[test]
+    fn style_for_missing_file() {
+        let lscolors1 = LsColors::from_string("mi=01:or=33;44");
+
+        let style_missing = lscolors1.style_for_indicator(Indicator::MissingFile).unwrap();
+        assert_eq!(FontStyle::bold(), style_missing.font_style);
+
+        let lscolors2 = LsColors::from_string("or=33;44");
+
+        let style_missing = lscolors2.style_for_indicator(Indicator::MissingFile).unwrap();
+        assert_eq!(Some(Color::Yellow), style_missing.foreground);
+    }
 }


### PR DESCRIPTION
- Introduces a new `enum` type for the different possible entries in the
  `LS_COLORS` variable (directories, files, symlinks, fifos, ...)
- Deprecates the direct public access to certain styles via
  `lscolors.directory` etc., but adds a new `style_for_indicator` method
  to get (read-only) access.
- Adds a fall-back logic for the `mi` style

see #15 and #13  