### PR TITLE
Move from tempdir to tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ authors = ["David Peter <mail@david-peter.de>"]
 ansi_term = { version = "0.11", optional = true }
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "^3"
 
 [features]
 default = ["ansi_term"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,8 +395,8 @@ mod tests {
         assert_eq!(None, style_artifact.background);
     }
 
-    fn temp_dir() -> tempdir::TempDir {
-        tempdir::TempDir::new("lscolors-test").expect("temporary directory")
+    fn temp_dir() -> tempfile::TempDir {
+        tempfile::tempdir().expect("temporary directory")
     }
 
     fn create_file<P: AsRef<Path>>(path: P) -> PathBuf {


### PR DESCRIPTION
tempdir is deprecated. See https://crates.io/crates/tempdir
_The tempdir crate is being merged into tempfile_