### PR TITLE
Add crossterm feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,18 @@ install:
 
 script:
   # Incorporate TARGET env var to the build and test process
-  - cargo build --target $TARGET --verbose
-  - RUST_BACKTRACE=1 cargo test --target $TARGET --verbose
-  - find . -maxdepth 3 | cargo run
+  - cargo build --no-default-features --target $TARGET --verbose
+  - RUST_BACKTRACE=1 cargo test --no-default-features --target $TARGET --verbose
+  - find . -maxdepth 3 | cargo run --no-default-features
+  - cargo build --features "ansi_term" --target $TARGET --verbose
+  - RUST_BACKTRACE=1 cargo test --features "ansi_term" --target $TARGET --verbose
+  - find . -maxdepth 3 | cargo run --features "ansi_term"
+  - cargo build --no-default-features --features "crossterm" --target $TARGET --verbose
+  - RUST_BACKTRACE=1 cargo test --no-default-features --features "crossterm" --target $TARGET --verbose
+  - find . -maxdepth 3 | cargo run --no-default-features --features "crossterm"
+  - cargo build --features "ansi_term crossterm" --target $TARGET --verbose
+  - RUST_BACKTRACE=1 cargo test --features "ansi_term crossterm" --target $TARGET --verbose
+  - find . -maxdepth 3 | cargo run --features "ansi_term crossterm"
 
 before_deploy:
   - bash ci/before_deploy.bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 
     # Minimum Rust supported channel.
     - os: linux
-      rust: 1.34.0
+      rust: 1.37.0
       env: TARGET=x86_64-unknown-linux-gnu
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,16 +47,13 @@ script:
   # Incorporate TARGET env var to the build and test process
   - cargo build --no-default-features --target $TARGET --verbose
   - RUST_BACKTRACE=1 cargo test --no-default-features --target $TARGET --verbose
-  - find . -maxdepth 3 | cargo run --no-default-features
   - cargo build --features "ansi_term" --target $TARGET --verbose
   - RUST_BACKTRACE=1 cargo test --features "ansi_term" --target $TARGET --verbose
-  - find . -maxdepth 3 | cargo run --features "ansi_term"
   - cargo build --no-default-features --features "crossterm" --target $TARGET --verbose
   - RUST_BACKTRACE=1 cargo test --no-default-features --features "crossterm" --target $TARGET --verbose
-  - find . -maxdepth 3 | cargo run --no-default-features --features "crossterm"
   - cargo build --features "ansi_term crossterm" --target $TARGET --verbose
   - RUST_BACKTRACE=1 cargo test --features "ansi_term crossterm" --target $TARGET --verbose
-  - find . -maxdepth 3 | cargo run --features "ansi_term crossterm"
+  - find . -maxdepth 3 | cargo run
 
 before_deploy:
   - bash ci/before_deploy.bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ authors = ["David Peter <mail@david-peter.de>"]
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
+crossterm = { version = "0.17", optional = true }
 
 [dev-dependencies]
 tempfile = "^3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,11 @@
 //! let style = lscolors.style_for_path(path);
 //!
 //! // If you want to use `ansi_term`:
+//! # #[cfg(features = "ansi_term")]
+//! # {
 //! let ansi_style = style.map(Style::to_ansi_term_style).unwrap_or_default();
 //! println!("{}", ansi_style.paint(path));
+//! # }
 //! ```
 
 mod fs;

--- a/src/style.rs
+++ b/src/style.rs
@@ -48,14 +48,18 @@ impl Color {
     #[cfg(feature = "crossterm")]
     pub fn to_crossterm_color(&self) -> crossterm::style::Color {
         match self {
-            Color::RGB(r, g, b) => crossterm::style::Color::RGB { r, g, b },
-            Color::Fixed(n) => crossterm::style::Color::AnsiValue(n),
+            Color::RGB(r, g, b) => crossterm::style::Color::Rgb {
+                r: *r,
+                g: *g,
+                b: *b,
+            },
+            Color::Fixed(n) => crossterm::style::Color::AnsiValue(*n),
             Color::Black => crossterm::style::Color::Black,
             Color::Red => crossterm::style::Color::Red,
             Color::Green => crossterm::style::Color::Green,
             Color::Yellow => crossterm::style::Color::Yellow,
             Color::Blue => crossterm::style::Color::Blue,
-            Color::Magenta => crossterm::style::Color::Purple,
+            Color::Magenta => crossterm::style::Color::Magenta,
             Color::Cyan => crossterm::style::Color::Cyan,
             Color::White => crossterm::style::Color::White,
         }
@@ -143,33 +147,33 @@ impl FontStyle {
     /// Convert to `crossterm::style::Attributes` (if the `crossterm` feature is enabled).
     #[cfg(feature = "crossterm")]
     pub fn to_crossterm_attributes(&self) -> crossterm::style::Attributes {
-        let mut attributes = Attributes::default();
+        let mut attributes = crossterm::style::Attributes::default();
         if self.bold {
-            attributes.set(Attribute::Bold);
+            attributes.set(crossterm::style::Attribute::Bold);
         }
         if self.dimmed {
-            attributes.set(Attribute::Dim);
+            attributes.set(crossterm::style::Attribute::Dim);
         }
         if self.italic {
-            attributes.set(Attribute::Italic);
+            attributes.set(crossterm::style::Attribute::Italic);
         }
         if self.underline {
-            attributes.set(Attribute::Underlined);
+            attributes.set(crossterm::style::Attribute::Underlined);
         }
         if self.slow_blink {
-            attributes.set(Attribute::SlowBlink);
+            attributes.set(crossterm::style::Attribute::SlowBlink);
         }
         if self.rapid_blink {
-            attributes.set(Attribute::RapidBlink);
+            attributes.set(crossterm::style::Attribute::RapidBlink);
         }
         if self.reverse {
-            attributes.set(Attribute::Reverse);
+            attributes.set(crossterm::style::Attribute::Reverse);
         }
         if self.hidden {
-            attributes.set(Attribute::Hidden);
+            attributes.set(crossterm::style::Attribute::Hidden);
         }
         if self.strikethrough {
-            attributes.set(Attribute::CrossedOut);
+            attributes.set(crossterm::style::Attribute::CrossedOut);
         }
         attributes
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -7,6 +7,9 @@ use std::collections::VecDeque;
 #[cfg(ansi_term)]
 use ansi_term;
 
+#[cfg(crossterm)]
+use crossterm;
+
 /// A `Color` can be one of the pre-defined ANSI colors (`Red`, `Green`, ..),
 /// a 8-bit ANSI color (`Fixed(u8)`) or a 24-bit color (`RGB(u8, u8, u8)`).
 #[derive(Debug, Clone, PartialEq)]
@@ -38,6 +41,23 @@ impl Color {
             Color::Magenta => ansi_term::Color::Purple,
             Color::Cyan => ansi_term::Color::Cyan,
             Color::White => ansi_term::Color::White,
+        }
+    }
+
+    /// Convert to a `crossterm::style::Color` (if the `crossterm` feature is enabled).
+    #[cfg(feature = "crossterm")]
+    pub fn to_crossterm_color(&self) -> crossterm::style::Color {
+        match self {
+            Color::RGB(r, g, b) => crossterm::style::Color::RGB { r, g, b },
+            Color::Fixed(n) => crossterm::style::Color::AnsiValue(n),
+            Color::Black => crossterm::style::Color::Black,
+            Color::Red => crossterm::style::Color::Red,
+            Color::Green => crossterm::style::Color::Green,
+            Color::Yellow => crossterm::style::Color::Yellow,
+            Color::Blue => crossterm::style::Color::Blue,
+            Color::Magenta => crossterm::style::Color::Purple,
+            Color::Cyan => crossterm::style::Color::Cyan,
+            Color::White => crossterm::style::Color::White,
         }
     }
 }
@@ -118,6 +138,40 @@ impl FontStyle {
             strikethrough: true,
             ..Default::default()
         }
+    }
+
+    /// Convert to `crossterm::style::Attributes` (if the `crossterm` feature is enabled).
+    #[cfg(feature = "crossterm")]
+    pub fn to_crossterm_attributes(&self) -> crossterm::style::Attributes {
+        let mut attributes = Attributes::default();
+        if self.bold {
+            attributes.set(Attribute::Bold);
+        }
+        if self.dimmed {
+            attributes.set(Attribute::Dim);
+        }
+        if self.italic {
+            attributes.set(Attribute::Italic);
+        }
+        if self.underline {
+            attributes.set(Attribute::Underlined);
+        }
+        if self.slow_blink {
+            attributes.set(Attribute::SlowBlink);
+        }
+        if self.rapid_blink {
+            attributes.set(Attribute::RapidBlink);
+        }
+        if self.reverse {
+            attributes.set(Attribute::Reverse);
+        }
+        if self.hidden {
+            attributes.set(Attribute::Hidden);
+        }
+        if self.strikethrough {
+            attributes.set(Attribute::CrossedOut);
+        }
+        attributes
     }
 }
 
@@ -260,6 +314,16 @@ impl Style {
         ansi_style.is_strikethrough = self.font_style.strikethrough;
 
         ansi_style
+    }
+
+    /// Convert to a `crossterm::style::ContentStyle` (if the `crossterm` feature is enabled).
+    #[cfg(feature = "crossterm")]
+    pub fn to_crossterm_style(&self) -> crossterm::style::ContentStyle {
+        crossterm::style::ContentStyle {
+            foreground_color: self.foreground.as_ref().map(Color::to_crossterm_color),
+            background_color: self.background.as_ref().map(Color::to_crossterm_color),
+            attributes: self.font_style.to_crossterm_attributes(),
+        }
     }
 }
 


### PR DESCRIPTION
Introduces a new cargo feature `crossterm` to be able to convert colors and styles to the corresponding structs/enums of [crossterm](https://github.com/crossterm-rs/crossterm).

Three methods are added:
- `to_crossterm_color`: Converts `lscolor::Color` to `crossterm::style::Color` (similiar to `to_ansi_term_color`)
- `to_crossterm_style`: Converts `lscolor::Style` to `crossterm::style::ContentStyle` (similiar to `to_ansi_term_style`)
- `to_crossterm_attributes`: Converts `lscolor::FontStyle` to `crossterm::style::Attributes`