### PR TITLE
Fix compiling for wasi

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,14 +1,12 @@
 use std::fs;
 
 #[cfg(any(unix, target_os = "redox"))]
-use std::os::unix::fs::PermissionsExt;
-
-#[cfg(any(unix, target_os = "redox"))]
 pub fn is_executable(md: &fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
     md.permissions().mode() & 0o111 != 0
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "wasi"))]
 pub fn is_executable(_: &fs::Metadata) -> bool {
     false
 }


### PR DESCRIPTION
As far as I understand, there is no concept of executability on wasi.

Though I do wonder if it wouldn't be prudent to just return `false` on 
```rust
#[cfg(not(any(unix, target_os = "redox")))]
```