### PR TITLE
Update crossterm to version 0.24

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -76,7 +76,7 @@ jobs:
           - { target: i686-pc-windows-msvc        , os: windows-2019                  }
           - { target: i686-unknown-linux-gnu      , os: ubuntu-20.04, use-cross: true }
           - { target: i686-unknown-linux-musl     , os: ubuntu-20.04, use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-10.15                   }
+          - { target: x86_64-apple-darwin         , os: macos-11                      }
           - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04                  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["David Peter <mail@david-peter.de>"]
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
-crossterm = { version = "0.23", optional = true }
+crossterm = { version = "0.24", optional = true }
 
 [dev-dependencies]
 tempfile = "^3"

--- a/src/style.rs
+++ b/src/style.rs
@@ -367,6 +367,7 @@ impl Style {
             foreground_color: self.foreground.as_ref().map(Color::to_crossterm_color),
             background_color: self.background.as_ref().map(Color::to_crossterm_color),
             attributes: self.font_style.to_crossterm_attributes(),
+            underline_color: self.foreground.as_ref().map(Color::to_crossterm_color),
         }
     }
 }


### PR DESCRIPTION
Necessary changes to be compatible with `crossterm = "0.24"`

This change currently adapts to the newly added
`crossterm::style::ContentStyle.underline_color`
by setting it simply to the foreground color.


Addresses #49

Will require a new release to be usable for compatibility with new crossterm version
