### PR TITLE
Don't set crossterms underline color/ Fix blink

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -367,7 +367,7 @@ impl Style {
             foreground_color: self.foreground.as_ref().map(Color::to_crossterm_color),
             background_color: self.background.as_ref().map(Color::to_crossterm_color),
             attributes: self.font_style.to_crossterm_attributes(),
-            underline_color: self.foreground.as_ref().map(Color::to_crossterm_color),
+            underline_color: None,
         }
     }
 }


### PR DESCRIPTION
We were observing blinking as an artifact for colored output in several
terminal emulators (e.g. Windows Terminal, Mac's Terminal.app)

https://github.com/nushell/nushell/pull/6172#issuecomment-1201856518

To resolve that, don't specifically set the underline color as it is
optional.