### PR TITLE
add the ability to have an underline in a separate color than text

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -325,6 +325,7 @@ impl Style {
                         break;
                     }
                 },
+                Some(59) => underline = None,
                 Some(90) => foreground = Some(Color::BrightBlack),
                 Some(91) => foreground = Some(Color::BrightRed),
                 Some(92) => foreground = Some(Color::BrightGreen),


### PR DESCRIPTION
This PR augments the `Style` struct to add the underline color as an `Option<Color>`. Previously, underline, which is ansi escape `58`, was not being parsed which was why the foreground color was being parsed as the underline color thereby making text blink on some terminals namely Mac's Terminal.app and Windows Terminal.

So, now when one calls `to_crossterm_style()`, if there is no underline set, underline will be set to None, and therefore not blink.

I also augmented the tests in style.rs to test a underline style.


Sorry for all the PRs from the nushell team. We've just been trying to upgrade to crossterm 0.24 and found these issues. Hopefully this is the last hotfix we come across for underlines. I have tested this PR with nushell and it seems to be working fine now with these changes in Windows Terminal.