### PR TITLE
Update crossterm to 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["David Peter <mail@david-peter.de>"]
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
-crossterm = { version = "0.24", optional = true }
+crossterm = { version = "0.25", optional = true }
 
 [dev-dependencies]
 tempfile = "^3"


### PR DESCRIPTION
   This is needed for reedline/nushell

   Compiling log v0.4.17
   Compiling autocfg v1.1.0
   Compiling parking_lot_core v0.9.3
   Compiling signal-hook v0.3.14
   Compiling scopeguard v1.1.0
   Compiling smallvec v1.9.0
   Compiling bitflags v1.3.2
   Compiling signal-hook-registry v1.4.0
   Compiling mio v0.8.4
   Compiling lock_api v0.4.8
   Compiling signal-hook-mio v0.2.3
   Compiling parking_lot v0.12.1
   Compiling crossterm v0.25.0
   Compiling lscolors v0.12.0 (/home/dbuch/dev/rust/lscolors)
    Finished test [unoptimized + debuginfo] target(s) in 5.91s
     Running unittests src/lib.rs (target/debug/deps/lscolors-c2975d0cc518b80e)

running 23 tests
test style::tests::ignore_unsupported_styles ... ok test style::tests::parse_24_bit_colors ... ok
test style::tests::parse_font_style ... ok
test style::tests::parse_8_bit_colors ... ok
test style::tests::parse_font_style_backwards ... ok test style::tests::parse_reject ... ok
test style::tests::parse_simple ... ok
test style::tests::support_reset_of_styles ... ok
test tests::basic_usage ... ok
test tests::default_styles_should_be_preserved ... ok test tests::override_disable_suffix ... ok
test tests::style_for_broken_symlink ... ok
test tests::style_for_dir_entry ... ok
test tests::style_for_file ... ok
test tests::style_for_directory ... ok
test tests::style_for_multi_hard_links ... ok
test tests::style_for_missing_file ... ok
test tests::style_for_path_uses_correct_ordering ... ok test tests::style_for_path_uses_lowercase_matching ... ok test tests::style_for_symlink ... ok
test tests::style_for_path_components ... ok
test tests::style_for_setid ... ok
test tests::style_for_sticky_other_writable ... ok

test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running unittests src/bin.rs (target/debug/deps/lscolors-60ae4747fc449a50)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests lscolors

running 1 test
test src/lib.rs - (line 4) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.44s