### PR TITLE
Use correct spelling for nu-ansi-term feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! let style = lscolors.style_for_path(path);
 //!
 //! // If you want to use `nu_ansi_term`:
-//! # #[cfg(features = "nu_ansi_term")]
+//! # #[cfg(features = "nu-ansi-term")]
 //! # {
 //! let ansi_style = style.map(Style::to_nu_ansi_term_style).unwrap_or_default();
 //! println!("{}", ansi_style.paint(path));


### PR DESCRIPTION
The feature in Cargo.toml is called "nu-ansi-term" not "nu_ansi_term"