### PR TITLE
update crossterm to 0.26

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,7 +1,7 @@
 name: CICD
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.56.0"
+  MIN_SUPPORTED_RUST_VERSION: "1.58.0"
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
 
 on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ authors = ["David Peter <mail@david-peter.de>"]
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
 nu-ansi-term = { version = "0.46", optional = true }
-crossterm = { version = "0.25", optional = true }
+crossterm = { version = "0.26", optional = true }
 
 [dev-dependencies]
 tempfile = "^3"


### PR DESCRIPTION
Hi, just found that the latest crossterm version is 0.26, I think it's good to update it to 0.26