### PR TITLE
Remove default features

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,7 +2,7 @@ name: CICD
 
 env:
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
-  MSRV_FEATURES: ""
+  MSRV_FEATURES: "--all-features"
 
 on:
   workflow_dispatch:
@@ -138,7 +138,7 @@ jobs:
 
     - name: Build
       shell: bash
-      run: $BUILD_CMD build --release --target=${{ matrix.job.target }}
+      run: $BUILD_CMD build --release --target=${{ matrix.job.target }} --features=nu-ansi-term
 
     - name: Set binary name & path
       id: bin
@@ -164,7 +164,7 @@ jobs:
       run: |
         # test only library unit tests and binary for arm-type targets
         unset CARGO_TEST_OPTIONS
-        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--lib --bin ${{ needs.crate_metadata.outputs.name }}" ;; esac;
+        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--all-features --lib --bin ${{ needs.crate_metadata.outputs.name }}" ;; esac;
         echo "CARGO_TEST_OPTIONS=${CARGO_TEST_OPTIONS}" >> $GITHUB_OUTPUT
 
     - name: Run tests
@@ -173,23 +173,23 @@ jobs:
 
     - name: Run lscolors
       shell: bash
-      run: $BUILD_CMD run --target=${{ matrix.job.target }} -- Cargo.toml Cargo.lock LICENSE-APACHE LICENSE-MIT README.md src/lib.rs
+      run: $BUILD_CMD run --target=${{ matrix.job.target }} --features nu-ansi-term -- Cargo.toml Cargo.lock LICENSE-APACHE LICENSE-MIT README.md src/lib.rs
 
     - name: "Feature check: ansi_term"
       shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features ansi_term
+      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ansi_term
 
     - name: "Feature check: nu-ansi-term"
       shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features nu-ansi-term
+      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features nu-ansi-term
 
     - name: "Feature check: crossterm"
       shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features crossterm
+      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features crossterm
 
     - name: "Feature check: ansi_term,nu-ansi-term,crossterm"
       shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --no-default-features --features ansi_term,nu-ansi-term,crossterm
+      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ansi_term,nu-ansi-term,crossterm
 
     - name: Create tarball
       id: package

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ edition = "2021"
 authors = ["David Peter <mail@david-peter.de>"]
 rust-version = "1.59.0"
 
+[features]
+default = []
+
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
 nu-ansi-term = { version = "0.46", optional = true }
@@ -26,13 +29,10 @@ crossterm = { version = "0.26", optional = true }
 [dev-dependencies]
 tempfile = "^3"
 
-[features]
-default = ["ansi_term", "nu-ansi-term"]
-
 [[bin]]
 name = "lscolors"
 path = "src/bin.rs"
-required-features = ["ansi_term", "nu-ansi-term"]
+required-features = ["nu-ansi-term"]
 
 [profile.release]
 lto = true


### PR DESCRIPTION
It seems wrong to make a choice for the user here. And certainly, no one wants to have two libraries activated.

This is a breaking change, unfortunately.