### PR TITLE
Update nu-ansi-term to 0.47

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
-nu-ansi-term = { version = "0.46", optional = true }
+nu-ansi-term = { version = "0.47", optional = true }
 crossterm = { version = "0.26", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.13.0"
 readme = "README.md"
 edition = "2021"
 authors = ["David Peter <mail@david-peter.de>"]
-rust-version = "1.59.0"
+rust-version = "1.62.1"
 
 [features]
 default = []


### PR DESCRIPTION
Hi, I also found that nu-ansi-term's version is 0.47, this pr is trying to update it up