### PR TITLE
Add `gnu_legacy` feature

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -59,12 +59,12 @@ jobs:
         components: clippy
     - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
       run: |
-        cargo clippy --all-targets gnu_legacy
-        cargo clippy --all-targets ${{ env.MSRV_FEATURES }}
+        cargo clippy --all-targets --features=gnu_legacy
+        cargo clippy --all-targets --features=${{ env.MSRV_FEATURES }}
     - name: Run tests
       run: |
-        cargo test gnu_legacy
-        cargo test ${{ env.MSRV_FEATURES }}
+        cargo test --features=gnu_legacy
+        cargo test --features=${{ env.MSRV_FEATURES }}
 
   documentation:
     name: Documentation
@@ -81,7 +81,7 @@ jobs:
         RUSTDOCFLAGS: -D warnings
       run: |
         cargo doc --no-deps --document-private-items --features=gnu_legacy
-        cargo doc --no-deps --document-private-items ${{ env.MSRV_FEATURES }}
+        cargo doc --no-deps --document-private-items --features=${{ env.MSRV_FEATURES }}
 
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -60,11 +60,11 @@ jobs:
     - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
       run: |
         cargo clippy --all-targets --features=gnu_legacy
-        cargo clippy --all-targets --features=${{ env.MSRV_FEATURES }}
+        cargo clippy --all-targets --features=crossterm,ansi_term,nu-ansi-term
     - name: Run tests
       run: |
         cargo test --features=gnu_legacy
-        cargo test --features=${{ env.MSRV_FEATURES }}
+        cargo test --features=crossterm,ansi_term,nu-ansi-term
 
   documentation:
     name: Documentation
@@ -81,7 +81,7 @@ jobs:
         RUSTDOCFLAGS: -D warnings
       run: |
         cargo doc --no-deps --document-private-items --features=gnu_legacy
-        cargo doc --no-deps --document-private-items --features=${{ env.MSRV_FEATURES }}
+        cargo doc --no-deps --document-private-items --features=crossterm,ansi_term,nu-ansi-term
 
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
@@ -102,6 +102,11 @@ jobs:
           - { target: x86_64-pc-windows-msvc      , os: windows-2019                  }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04, use-cross: true }
+        terminal:
+          - ansi_term
+          - crossterm
+          - nu-ansi-term
+          - gnu_legacy
     env:
       BUILD_CMD: cargo
     steps:
@@ -144,7 +149,7 @@ jobs:
 
     - name: Build
       shell: bash
-      run: $BUILD_CMD build --release --target=${{ matrix.job.target }} --features=nu-ansi-term
+      run: $BUILD_CMD build --release --target=${{ matrix.job.target }} --features=${{ matrix.terminal }}
 
     - name: Set binary name & path
       id: bin
@@ -167,40 +172,25 @@ jobs:
     - name: Run tests for all other targets
       shell: bash
       if: contains(fromJson('["arm-", "aarch64-"]'), github.event.action)
-      run: |
-        $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ env.MSRV_FEATURES }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
-        $BUILD_CMD test --target=${{ matrix.job.target }} --features=gnu_legacy --lib --bin ${{ needs.crate_metadata.outputs.name }}
+      run: $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ matrix.terminal }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run tests for arm and aarch64
       shell: bash
       if: ${{ !contains(fromJson('["arm-", "aarch64-"]'), github.event.action) }}
-      run: |
-        $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ env.MSRV_FEATURES }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
-        $BUILD_CMD test --target=${{ matrix.job.target }} --features=gnu_legacy --lib --bin ${{ needs.crate_metadata.outputs.name }}
+      run: $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ matrix.terminal }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run lscolors
       shell: bash
-      run: $BUILD_CMD run --target=${{ matrix.job.target }} --features nu-ansi-term -- Cargo.toml Cargo.lock LICENSE-APACHE LICENSE-MIT README.md src/lib.rs
+      run: $BUILD_CMD run --target=${{ matrix.job.target }} --features ${{ matrix.terminal }} -- Cargo.toml Cargo.lock LICENSE-APACHE LICENSE-MIT README.md src/lib.rs
 
-    - name: "Feature check: ansi_term"
+    - name: "Feature check: ${{ matrix.terminal }}"
       shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ansi_term
-
-    - name: "Feature check: nu-ansi-term"
-      shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features nu-ansi-term
-
-    - name: "Feature check: crossterm"
-      shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features crossterm
+      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ${{ matrix.terminal }}
 
     - name: "Feature check: ansi_term,nu-ansi-term,crossterm"
+      if: ${{ matrix.terminal == "nu-ansi-term" }}
       shell: bash
       run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ansi_term,nu-ansi-term,crossterm
-
-    - name: "Feature check: gnu_legacy"
-      shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features gnu_legacy
 
     - name: Create tarball
       id: package

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,7 +2,6 @@ name: CICD
 
 env:
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
-  MSRV_FEATURES: "crossterm,ansi_term,nu-ansi-term"
 
 on:
   workflow_dispatch:
@@ -84,7 +83,7 @@ jobs:
         cargo doc --no-deps --document-private-items --features=crossterm,ansi_term,nu-ansi-term
 
   build:
-    name: ${{ matrix.job.target }} (${{ matrix.job.os }})
+    name: ${{ matrix.job.target }} (${{ matrix.job.os }} with ${{ matrix.terminal }})
     runs-on: ${{ matrix.job.os }}
     needs: crate_metadata
     strategy:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,7 +2,7 @@ name: CICD
 
 env:
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
-  MSRV_FEATURES: "--all-features"
+  MSRV_FEATURES: "crossterm,ansi_term,nu-ansi-term"
 
 on:
   workflow_dispatch:
@@ -58,9 +58,13 @@ jobs:
         toolchain: ${{ needs.crate_metadata.outputs.msrv }}
         components: clippy
     - name: Run clippy (on minimum supported rust version to prevent warnings we can't fix)
-      run: cargo clippy --all-targets ${{ env.MSRV_FEATURES }}
+      run: |
+        cargo clippy --all-targets gnu_legacy
+        cargo clippy --all-targets ${{ env.MSRV_FEATURES }}
     - name: Run tests
-      run: cargo test ${{ env.MSRV_FEATURES }}
+      run: |
+        cargo test gnu_legacy
+        cargo test ${{ env.MSRV_FEATURES }}
 
   documentation:
     name: Documentation
@@ -77,7 +81,7 @@ jobs:
         RUSTDOCFLAGS: -D warnings
       run: |
         cargo doc --no-deps --document-private-items --features=gnu_legacy
-        cargo doc --no-deps --document-private-items --features=ansi_term,crossterm,nu-ansi-term
+        cargo doc --no-deps --document-private-items ${{ env.MSRV_FEATURES }}
 
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -173,7 +173,7 @@ jobs:
 
     - name: Run tests for arm and aarch64
       shell: bash
-      if: contains(fromJson('["arm-", "aarch64-"]'), github.event.action)
+      if: ${{ !contains(fromJson('["arm-", "aarch64-"]'), github.event.action) }}
       run: |
         $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ env.MSRV_FEATURES }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
         $BUILD_CMD test --target=${{ matrix.job.target }} --features=gnu_legacy --lib --bin ${{ needs.crate_metadata.outputs.name }}

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -75,7 +75,8 @@ jobs:
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings
-      run: cargo doc --no-deps --document-private-items --all-features
+      run: cargo doc --no-deps --document-private-items --features=gnu_legacy
+      run: cargo doc --no-deps --document-private-items --features=ansi_term,crossterm,nu-ansi-term
 
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -186,11 +186,6 @@ jobs:
       shell: bash
       run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ${{ matrix.terminal }}
 
-    - name: "Feature check: ansi_term,nu-ansi-term,crossterm"
-      if: matrix.terminal == 'nu-ansi-term'
-      shell: bash
-      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ansi_term,nu-ansi-term,crossterm
-
     - name: Create tarball
       id: package
       shell: bash

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -170,12 +170,12 @@ jobs:
 
     - name: Run tests for all other targets
       shell: bash
-      if: contains(fromJson('["arm-", "aarch64-"]'), github.event.action)
+      if: ${{ !contains(fromJson('["arm-", "aarch64-"]'), matrix.job.target) }}
       run: $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ matrix.terminal }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run tests for arm and aarch64
       shell: bash
-      if: ${{ !contains(fromJson('["arm-", "aarch64-"]'), github.event.action) }}
+      if: contains(fromJson('["arm-", "aarch64-"]'), matrix.job.target)
       run: $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ matrix.terminal }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run lscolors

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -188,7 +188,7 @@ jobs:
       run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ${{ matrix.terminal }}
 
     - name: "Feature check: ansi_term,nu-ansi-term,crossterm"
-      if: ${{ matrix.terminal == "nu-ansi-term" }}
+      if: matrix.terminal == 'nu-ansi-term'
       shell: bash
       run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ansi_term,nu-ansi-term,crossterm
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -170,12 +170,12 @@ jobs:
 
     - name: Run tests for all other targets
       shell: bash
-      if: ${{ !contains('["arm-", "aarch64-"]', matrix.job.target) }}
+      if: ${{ !startsWith(matrix.job.target, 'a') }}
       run: $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ matrix.terminal }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run tests for arm and aarch64
       shell: bash
-      if: contains('["arm-", "aarch64-"]', matrix.job.target)
+      if: startsWith(matrix.job.target, 'a')
       run: $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ matrix.terminal }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run lscolors

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -164,18 +164,19 @@ jobs:
         echo "BIN_PATH=${BIN_PATH}" >> $GITHUB_OUTPUT
         echo "BIN_NAME=${BIN_NAME}" >> $GITHUB_OUTPUT
 
-    - name: Set testing options
-      id: test-options
+    - name: Run tests for all other targets
       shell: bash
+      if: contains(fromJson('["arm-", "aarch64-"]'), github.event.action)
       run: |
-        # test only library unit tests and binary for arm-type targets
-        unset CARGO_TEST_OPTIONS
-        unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--all-features --lib --bin ${{ needs.crate_metadata.outputs.name }}" ;; esac;
-        echo "CARGO_TEST_OPTIONS=${CARGO_TEST_OPTIONS}" >> $GITHUB_OUTPUT
+        $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ env.MSRV_FEATURES }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
+        $BUILD_CMD test --target=${{ matrix.job.target }} --features=gnu_legacy --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
-    - name: Run tests
+    - name: Run tests for arm and aarch64
       shell: bash
-      run: $BUILD_CMD test --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
+      if: contains(fromJson('["arm-", "aarch64-"]'), github.event.action)
+      run: |
+        $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ env.MSRV_FEATURES }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
+        $BUILD_CMD test --target=${{ matrix.job.target }} --features=gnu_legacy --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run lscolors
       shell: bash
@@ -196,6 +197,10 @@ jobs:
     - name: "Feature check: ansi_term,nu-ansi-term,crossterm"
       shell: bash
       run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features ansi_term,nu-ansi-term,crossterm
+
+    - name: "Feature check: gnu_legacy"
+      shell: bash
+      run: $BUILD_CMD check --target=${{ matrix.job.target }} --verbose --lib --features gnu_legacy
 
     - name: Create tarball
       id: package

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -75,8 +75,9 @@ jobs:
     - name: Check documentation
       env:
         RUSTDOCFLAGS: -D warnings
-      run: cargo doc --no-deps --document-private-items --features=gnu_legacy
-      run: cargo doc --no-deps --document-private-items --features=ansi_term,crossterm,nu-ansi-term
+      run: |
+        cargo doc --no-deps --document-private-items --features=gnu_legacy
+        cargo doc --no-deps --document-private-items --features=ansi_term,crossterm,nu-ansi-term
 
   build:
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -170,12 +170,12 @@ jobs:
 
     - name: Run tests for all other targets
       shell: bash
-      if: ${{ !contains(fromJson('["arm-", "aarch64-"]'), matrix.job.target) }}
+      if: ${{ !contains('["arm-", "aarch64-"]', matrix.job.target) }}
       run: $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ matrix.terminal }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run tests for arm and aarch64
       shell: bash
-      if: contains(fromJson('["arm-", "aarch64-"]'), matrix.job.target)
+      if: contains('["arm-", "aarch64-"]', matrix.job.target)
       run: $BUILD_CMD test --target=${{ matrix.job.target }} --features=${{ matrix.terminal }} --lib --bin ${{ needs.crate_metadata.outputs.name }}
 
     - name: Run lscolors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["David Peter <mail@david-peter.de>"]
 rust-version = "1.62.1"
 
 [features]
-default = ["crossterm"]
+default = []
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ default = []
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
-nu-ansi-term= { package = "nu-ansi-term", git = "https://github.com/nushell/nu-ansi-term.git", optional = true }
-gnu_legacy = { package = "nu-ansi-term", git = "https://github.com/nushell/nu-ansi-term.git", features = ["gnu_legacy"], optional = true }
+nu-ansi-term= { package = "nu-ansi-term", git = "https://github.com/nushell/nu-ansi-term.git", optional = true, rev = "313eac4" }
+gnu_legacy = { package = "nu-ansi-term", git = "https://github.com/nushell/nu-ansi-term.git", features = ["gnu_legacy"], optional = true, rev = "313eac4" }
 crossterm = { version = "0.26", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ tempfile = "^3"
 [[bin]]
 name = "lscolors"
 path = "src/bin.rs"
-required-features = ["nu-ansi-term"]
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ authors = ["David Peter <mail@david-peter.de>"]
 rust-version = "1.62.1"
 
 [features]
-default = []
+default = ["crossterm"]
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ default = []
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
-nu-ansi-term = { version = "0.47", optional = true }
+nu-ansi-term= { package = "nu-ansi-term", git = "https://github.com/nushell/nu-ansi-term.git", optional = true }
+gnu_legacy = { package = "nu-ansi-term", git = "https://github.com/nushell/nu-ansi-term.git", features = ["gnu_legacy"], optional = true }
 crossterm = { version = "0.26", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ let ansi_style = style.map(Style::to_ansi_term_style)
                       .unwrap_or_default();
 println!("{}", ansi_style.paint(path));
 
-// If you want to use `nu-ansi-term` (fork of ansi_term):
+// If you want to use `nu-ansi-term or gnu_legacy` (fork of ansi_term):
 let ansi_style = style.map(Style::to_nu_ansi_term_style)
                       .unwrap_or_default();
 println!("{}", ansi_style.paint(path));
@@ -33,6 +33,7 @@ println!("{}", ansi_style.paint(path));
 
 This crate also comes with a small command-line program `lscolors` that
 can be used to colorize the output of other commands:
+
 ```bash
 > find . -maxdepth 2 | lscolors
 
@@ -42,16 +43,33 @@ can be used to colorize the output of other commands:
 You can install it by running `cargo install lscolors` or by downloading one
 of the prebuilt binaries from the [release page](https://github.com/sharkdp/lscolors/releases).
 If you want to build the application from source, you can run
+
 ```rs
 cargo build --release --features=nu-ansi-term --locked
+```
+
+## Features
+
+```rust
+// Cargo.toml
+
+[dependencies]
+// use ansi-term coloring
+lscolors = { version = "v0.14.0", features = ["ansi_term"] }
+// use across-term coloring
+lscolors = { version = "v0.14.0", features = ["crossterm"] }
+// use nu-ansi-term coloring
+lscolors = { version = "v0.14.0", features = ["nu-ansi-term"] }
+// use nu-ansi-term coloring in gnu legacy mode, double digit styles and reset codes before coloring
+lscolors = { version = "v0.14.0", features = ["gnu_legacy"] }
 ```
 
 ## License
 
 Licensed under either of
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ let ansi_style = style.map(Style::to_ansi_term_style)
                       .unwrap_or_default();
 println!("{}", ansi_style.paint(path));
 
-// If you want to use `nu-ansi-term or gnu_legacy` (fork of ansi_term):
-let ansi_style = style.map(Style::to_nu_ansi_term_style)
+// If you want to use `nu-ansi-term` (fork of ansi_term) or `gnu_legacy`:
+let nu_ansi_style = style.map(Style::to_nu_ansi_term_style)
                       .unwrap_or_default();
-println!("{}", ansi_style.paint(path));
+println!("{}", nu_ansi_style.paint(path));
+
+// If you want to use `crossterm`:
+let crossterm_style = style.map(Style::to_crossterm_style)
+                      .unwrap_or_default();
+println!("{}", crossterm_style.apply(path));
 ```
 
 ## Command-line application
@@ -56,11 +61,11 @@ cargo build --release --features=nu-ansi-term --locked
 [dependencies]
 // use ansi-term coloring
 lscolors = { version = "v0.14.0", features = ["ansi_term"] }
-// use across-term coloring
+// use crossterm coloring
 lscolors = { version = "v0.14.0", features = ["crossterm"] }
 // use nu-ansi-term coloring
 lscolors = { version = "v0.14.0", features = ["nu-ansi-term"] }
-// use nu-ansi-term coloring in gnu legacy mode, double digit styles and reset codes before coloring
+// use nu-ansi-term coloring in gnu legacy mode with double digit styles
 lscolors = { version = "v0.14.0", features = ["gnu_legacy"] }
 ```
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -5,7 +5,12 @@ use std::path::Path;
 
 use lscolors::{LsColors, Style};
 
-#[cfg(all(not(feature = "nu-ansi-term"), not(feature = "gnu_legacy"),not(feature = "ansi_term"), not(feature = "crossterm")))]
+#[cfg(all(
+    not(feature = "nu-ansi-term"),
+    not(feature = "gnu_legacy"),
+    not(feature = "ansi_term"),
+    not(feature = "crossterm")
+))]
 compile_error!("one feature must be enabled: ansi_term, nu-ansi-term, crossterm, gnu_legacy");
 
 #[cfg(any(feature = "nu-ansi-term", feature = "gnu_legacy"))]

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -13,33 +13,27 @@ use lscolors::{LsColors, Style};
 ))]
 compile_error!("one feature must be enabled: ansi_term, nu-ansi-term, crossterm, gnu_legacy");
 
-#[cfg(any(feature = "nu-ansi-term", feature = "gnu_legacy"))]
 fn print_path(handle: &mut dyn Write, ls_colors: &LsColors, path: &str) -> io::Result<()> {
     for (component, style) in ls_colors.style_for_path_components(Path::new(path)) {
-        let ansi_style = style.map(Style::to_nu_ansi_term_style).unwrap_or_default();
-        write!(handle, "{}", ansi_style.paint(component.to_string_lossy()))?;
-    }
-    writeln!(handle)?;
 
-    Ok(())
-}
+        #[cfg(any(feature = "nu-ansi-term", feature = "gnu_legacy"))]
+        {
+            let ansi_style = style.map(Style::to_nu_ansi_term_style).unwrap_or_default();
+            write!(handle, "{}", ansi_style.paint(component.to_string_lossy()))?;
+        }
 
-#[cfg(feature = "ansi_term")]
-fn print_path(handle: &mut dyn Write, ls_colors: &LsColors, path: &str) -> io::Result<()> {
-    for (component, style) in ls_colors.style_for_path_components(Path::new(path)) {
-        let ansi_style = style.map(Style::to_ansi_term_style).unwrap_or_default();
-        write!(handle, "{}", ansi_style.paint(component.to_string_lossy()))?;
-    }
-    writeln!(handle)?;
+        #[cfg(feature = "ansi_term")]
+        {
+            let ansi_style = style.map(Style::to_ansi_term_style).unwrap_or_default();
+            write!(handle, "{}", ansi_style.paint(component.to_string_lossy()))?;
+        }
 
-    Ok(())
-}
 
-#[cfg(feature = "crossterm")]
-fn print_path(handle: &mut dyn Write, ls_colors: &LsColors, path: &str) -> io::Result<()> {
-    for (component, style) in ls_colors.style_for_path_components(Path::new(path)) {
-        let ansi_style = style.map(Style::to_crossterm_style).unwrap_or_default();
-        write!(handle, "{}", ansi_style.apply(component.to_string_lossy()))?;
+        #[cfg(feature = "crossterm")]
+        {
+            let ansi_style = style.map(Style::to_crossterm_style).unwrap_or_default();
+            write!(handle, "{}", ansi_style.apply(component.to_string_lossy()))?;
+        }
     }
     writeln!(handle)?;
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -15,7 +15,6 @@ compile_error!("one feature must be enabled: ansi_term, nu-ansi-term, crossterm,
 
 fn print_path(handle: &mut dyn Write, ls_colors: &LsColors, path: &str) -> io::Result<()> {
     for (component, style) in ls_colors.style_for_path_components(Path::new(path)) {
-
         #[cfg(any(feature = "nu-ansi-term", feature = "gnu_legacy"))]
         {
             let ansi_style = style.map(Style::to_nu_ansi_term_style).unwrap_or_default();
@@ -27,7 +26,6 @@ fn print_path(handle: &mut dyn Write, ls_colors: &LsColors, path: &str) -> io::R
             let ansi_style = style.map(Style::to_ansi_term_style).unwrap_or_default();
             write!(handle, "{}", ansi_style.paint(component.to_string_lossy()))?;
         }
-
 
         #[cfg(feature = "crossterm")]
         {

--- a/src/style.rs
+++ b/src/style.rs
@@ -2,6 +2,10 @@
 //!
 //! For more information, see
 //! [ANSI escape code (Wikipedia)](https://en.wikipedia.org/wiki/ANSI_escape_code).
+#[cfg(feature = "gnu_legacy")]
+use gnu_legacy as nu_ansi_term;
+#[cfg(feature = "nu-ansi-term")]
+use nu_ansi_term;
 use std::collections::VecDeque;
 
 /// A `Color` can be one of the pre-defined ANSI colors (`Red`, `Green`, ..),
@@ -58,7 +62,7 @@ impl Color {
     }
 
     /// Convert to a `nu_ansi_term::Color` (if the `nu_ansi_term` feature is enabled).
-    #[cfg(feature = "nu-ansi-term")]
+    #[cfg(any(feature = "nu-ansi-term", feature = "gnu_legacy"))]
     pub fn to_nu_ansi_term_color(&self) -> nu_ansi_term::Color {
         match self {
             Color::RGB(r, g, b) => nu_ansi_term::Color::Rgb(*r, *g, *b),
@@ -399,7 +403,7 @@ impl Style {
     }
 
     /// Convert to a `nu_ansi_term::Style` (if the `nu_ansi_term` feature is enabled).
-    #[cfg(feature = "nu-ansi-term")]
+    #[cfg(any(feature = "nu-ansi-term", feature = "gnu_legacy"))]
     pub fn to_nu_ansi_term_style(&self) -> nu_ansi_term::Style {
         nu_ansi_term::Style {
             foreground: self.foreground.as_ref().map(Color::to_nu_ansi_term_color),
@@ -412,6 +416,10 @@ impl Style {
             is_reverse: self.font_style.reverse,
             is_hidden: self.font_style.hidden,
             is_strikethrough: self.font_style.strikethrough,
+            #[cfg(feature = "gnu_legacy")]
+            with_reset: true,
+            #[cfg(not(feature = "gnu_legacy"))]
+            with_reset: false,
         }
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -243,8 +243,6 @@ pub struct Style {
     pub underline: Option<Color>,
 }
 
-
-
 impl Style {
     /// Parse ANSI escape sequences like `38;2;255;0;100;1;4` (pink, bold, underlined).
     pub fn from_ansi_sequence(code: &str) -> Option<Style> {

--- a/src/style.rs
+++ b/src/style.rs
@@ -243,6 +243,8 @@ pub struct Style {
     pub underline: Option<Color>,
 }
 
+
+
 impl Style {
     /// Parse ANSI escape sequences like `38;2;255;0;100;1;4` (pink, bold, underlined).
     pub fn from_ansi_sequence(code: &str) -> Option<Style> {
@@ -465,67 +467,6 @@ impl Style {
         }
     }
 
-    /// Convert to a `nu_ansi_term::Style` (if the `nu-ansi-term` or `gnu_legacy` feature is enabled).
-    ///
-    /// ## Example for nu-ansi-term feature
-    /// ```
-    /// # #[cfg(feature = "nu-ansi-term")]
-    /// # {
-    ///
-    /// use lscolors::{Color, FontStyle, Style};
-    ///
-    /// let style = Style {
-    ///     font_style: FontStyle {
-    ///         bold: true,
-    ///         ..Default::default()
-    ///     },
-    ///     foreground: Some(Color::Blue),
-    ///     ..Default::default()
-    /// };
-    /// let nu_ansi = style.to_nu_ansi_term_style_with_reset();
-    /// assert_eq!("\x1b[0m\x1b[1;34mwow\x1b[0m", nu_ansi.paint("wow").to_string());
-    /// # }
-    /// ```
-    /// ## Example for gnu_legacy feature
-    /// ```
-    /// # #[cfg(feature = "gnu_legacy")]
-    /// # {
-    ///
-    /// use lscolors::{Color, FontStyle, Style};
-    ///
-    /// let style = Style {
-    ///     font_style: FontStyle {
-    ///         bold: true,
-    ///         ..Default::default()
-    ///     },
-    ///     foreground: Some(Color::Blue),
-    ///     ..Default::default()
-    /// };
-    /// let nu_ansi = style.to_nu_ansi_term_style_with_reset();
-    /// assert_eq!(
-    ///     "\x1b[0m\x1b[01;34mwow\x1b[0m",
-    ///     nu_ansi.paint("wow").to_string()
-    /// );
-    /// # }
-    /// ```
-    ///
-    #[cfg(any(feature = "nu-ansi-term", feature = "gnu_legacy"))]
-    pub fn to_nu_ansi_term_style_with_reset(&self) -> nu_ansi_term::Style {
-        nu_ansi_term::Style {
-            foreground: self.foreground.as_ref().map(Color::to_nu_ansi_term_color),
-            background: self.background.as_ref().map(Color::to_nu_ansi_term_color),
-            is_bold: self.font_style.bold,
-            is_dimmed: self.font_style.dimmed,
-            is_italic: self.font_style.italic,
-            is_underline: self.font_style.underline,
-            is_blink: self.font_style.rapid_blink || self.font_style.slow_blink,
-            is_reverse: self.font_style.reverse,
-            is_hidden: self.font_style.hidden,
-            is_strikethrough: self.font_style.strikethrough,
-            with_reset: true,
-        }
-    }
-
     /// Convert to a `crossterm::style::ContentStyle` (if the `crossterm` feature is enabled).
     #[cfg(feature = "crossterm")]
     pub fn to_crossterm_style(&self) -> crossterm::style::ContentStyle {
@@ -540,7 +481,7 @@ impl Style {
 
 #[cfg(test)]
 mod tests {
-    use super::{Color, FontStyle, Style};
+    use super::*;
 
     fn assert_style(
         code: &str,
@@ -746,7 +687,7 @@ mod tests {
             foreground: Some(Color::Blue),
             ..Default::default()
         };
-        let nu_ansi = style.to_nu_ansi_term_style_with_reset();
+        let nu_ansi = style.to_nu_ansi_term_style().reset_before_style();
         assert_eq!(
             "\x1b[0m\x1b[1;34mwow\x1b[0m",
             nu_ansi.paint("wow").to_string()
@@ -779,7 +720,7 @@ mod tests {
             foreground: Some(Color::Blue),
             ..Default::default()
         };
-        let nu_ansi = style.to_nu_ansi_term_style_with_reset();
+        let nu_ansi = style.to_nu_ansi_term_style().reset_before_style();
         assert_eq!(
             "\x1b[0m\x1b[01;34mwow\x1b[0m",
             nu_ansi.paint("wow").to_string()
@@ -802,7 +743,7 @@ mod tests {
         let style = Style {
             ..Default::default()
         };
-        let nu_ansi = style.to_nu_ansi_term_style_with_reset();
+        let nu_ansi = style.to_nu_ansi_term_style().reset_before_style();
         assert_eq!("\x1b[0m\x1b[mwow\x1b[0m", nu_ansi.paint("wow").to_string());
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -747,7 +747,10 @@ mod tests {
             ..Default::default()
         };
         let nu_ansi = style.to_nu_ansi_term_style_with_reset();
-        assert_eq!("\x1b[0m\x1b[1;34mwow\x1b[0m", nu_ansi.paint("wow").to_string());
+        assert_eq!(
+            "\x1b[0m\x1b[1;34mwow\x1b[0m",
+            nu_ansi.paint("wow").to_string()
+        );
     }
 
     #[cfg(feature = "gnu_legacy")]
@@ -762,10 +765,7 @@ mod tests {
             ..Default::default()
         };
         let nu_ansi = style.to_nu_ansi_term_style();
-        assert_eq!(
-            "\x1b[01;34mwow\x1b[0m",
-            nu_ansi.paint("wow").to_string()
-        );
+        assert_eq!("\x1b[01;34mwow\x1b[0m", nu_ansi.paint("wow").to_string());
     }
 
     #[cfg(feature = "gnu_legacy")]

--- a/src/style.rs
+++ b/src/style.rs
@@ -410,24 +410,40 @@ impl Style {
     /// ```
     /// # #[cfg(feature = "nu-ansi-term")]
     /// # {
-    /// use lscolors::Style;
     ///
-    /// let style = Style { ..Default::default() };
+    /// use lscolors::{Color, FontStyle, Style};
+    ///
+    /// let style = Style {
+    ///     font_style: FontStyle {
+    ///         bold: true,
+    ///         ..Default::default()
+    ///     },
+    ///     foreground: Some(Color::Blue),
+    ///     ..Default::default()
+    /// };
     /// let nu_ansi = style.to_nu_ansi_term_style();
-    /// assert_eq!("wow", nu_ansi.paint("wow").to_string());
+    /// assert_eq!("\x1b[1;34mwow\x1b[0m", nu_ansi.paint("wow").to_string());
     /// # }
     /// ```
     /// ## Example for gnu_legacy feature
     /// ```
     /// # #[cfg(feature = "gnu_legacy")]
     /// # {
-    /// use lscolors::Style;
     ///
-    /// let style = Style { ..Default::default() };
+    /// use lscolors::{Color, FontStyle, Style};
+    ///
+    /// let style = Style {
+    ///     font_style: FontStyle {
+    ///         bold: true,
+    ///         ..Default::default()
+    ///     },
+    ///     foreground: Some(Color::Blue),
+    ///     ..Default::default()
+    /// };
     /// let nu_ansi = style.to_nu_ansi_term_style();
     /// assert_eq!(
-    ///    "\x1b[0m\x1b[mwow\x1b[0m",
-    ///    nu_ansi.paint("wow").to_string()
+    ///     "\x1b[0m\x1b[01;34mwow\x1b[0m",
+    ///     nu_ansi.paint("wow").to_string()
     /// );
     /// # }
     /// ```
@@ -716,6 +732,9 @@ mod tests {
             ..Default::default()
         };
         let cross = style.to_crossterm_style();
-        assert_eq!("\x1b[1;34mwow\x1b[0m", cross.paint("wow").to_string());
+        assert_eq!(
+            "\x1b[38;5;4m\x1b[1mwow\x1b[0m",
+            cross.apply("wow").to_string()
+        );
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -63,7 +63,7 @@ impl Color {
         }
     }
 
-    /// Convert to a `nu_ansi_term::Color` (if the `nu_ansi_term` feature is enabled).
+    /// Convert to a `nu_ansi_term::Color` (if the `nu_ansi_term` or `gnu_legacy` feature is enabled).
     #[cfg(any(feature = "nu-ansi-term", feature = "gnu_legacy"))]
     pub fn to_nu_ansi_term_color(&self) -> nu_ansi_term::Color {
         match self {


### PR DESCRIPTION
Hi,
this crate is used in the rust drop-in replacement for gnu coreutils called [uucoreutils](https://github.com/uutils/coreutils).
The original GNU util `ls` is still using some extended modes that are yet not supported by this crate.
1. two-digit style codes
2. reset prefix for any string

To continue using this crate, it would really help to improve on those two topics. This PR will add both functionalities.

nu-ansi-term still needs to officially release the feature, so this is a draft for now.

After the merge, [this GNU test](https://github.com/coreutils/coreutils/blob/master/tests/ls/color-term.sh) will turn green:

#### OLD
```shell
FAIL: tests/ls/color-term
=========================

--- exp 2023-05-16 15:56:30.337121900 +0200
+++ out 2023-05-16 15:56:30.102644900 +0200
@@ -1,4 +1,4 @@
-^[[0m^[[01;32mexe^[[0m$
-^[[0m^[[01;32mexe^[[0m$
+^[[1;32mexe^[[0m$
+^[[1;32mexe^[[0m$
 exe$
 exe$
FAIL tests/ls/color-term.sh (exit status: 1)
```
#### After both PRs
```shell
SUCCESS: tests/ls/color-term
=========================
@@ -1,4 +1,4 @@
^[[0m^[[01;32mexe^[[0m$
^[[0m^[[01;32mexe^[[0m$
 exe$
 exe$
SUCCESS tests/ls/color-term.sh (exit status: 0)
```

Thanks for your help!
