### PR TITLE
Upgrade to `nu-ansi-term` 0.48.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
-nu-ansi-term = { version = "0.47", optional = true }
+nu-ansi-term = { version = "0.48", optional = true }
 crossterm = { version = "0.26", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This release includes support for `gnu_legacy` output of CSI sequences via a feature gate. This should resolve one of the outstanding issues in https://github.com/sharkdp/lscolors/issues/48

For the full release notes see:
https://github.com/nushell/nu-ansi-term/releases/tag/v0.48.0

cc @alexkunde