### PR TITLE
Upgrade to `nu-ansi-term` 0.49

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
-nu-ansi-term = { version = "0.47", optional = true }
+nu-ansi-term = { version = "0.49", optional = true }
 crossterm = { version = "0.26", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.14.0"
 readme = "README.md"
 edition = "2021"
 authors = ["David Peter <mail@david-peter.de>"]
-rust-version = "1.62.1"
+rust-version = "1.63.0"
 
 [features]
 default = []

--- a/src/style.rs
+++ b/src/style.rs
@@ -412,6 +412,7 @@ impl Style {
             is_reverse: self.font_style.reverse,
             is_hidden: self.font_style.hidden,
             is_strikethrough: self.font_style.strikethrough,
+            prefix_with_reset: false,
         }
     }
 


### PR DESCRIPTION
This release fixes the problem that blocked #68

This PR just keeps the behavior as before and does not yet incorporate
the GNU compatibility focussed changes as worked on in #66
