### PR TITLE
Bump version for `0.15.0` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
     "color"
 ]
 license = "MIT/Apache-2.0"
-version = "0.14.0"
+version = "0.15.0"
 readme = "README.md"
 edition = "2021"
 authors = ["David Peter <mail@david-peter.de>"]


### PR DESCRIPTION
This release updates `nu-ansi-term` to version 0.49.0.
Furthermore increases MSRV to 1.63.0
