### PR TITLE
Add an option to style any string without path verification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,6 +616,22 @@ mod tests {
     }
 
     #[test]
+    fn style_for_str() {
+        let lscolors = LsColors::from_string("*.wav=00;36:*.rs=1;38;5;202:");
+        let files = ["", "test.wav", "test.rs"];
+        for file in files {
+            if let Some(style) = lscolors.style_for_str(file) {
+                let color = match file {
+                    "test.wav" => Some(Color::Cyan),
+                    "test.rs" => Some(Color::Fixed(202)),
+                    _ => unreachable!(),
+                };
+                assert_eq!(color, style.foreground);
+            }
+        }
+    }
+
+    #[test]
     fn style_for_directory() {
         let tmp_dir = temp_dir();
         let style = get_default_style(tmp_dir.path()).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,17 +618,17 @@ mod tests {
     #[test]
     fn style_for_str() {
         let lscolors = LsColors::from_string("*.wav=00;36:*.rs=1;38;5;202:");
-        let files = ["", "test.wav", "test.rs"];
-        for file in files {
-            if let Some(style) = lscolors.style_for_str(file) {
-                let color = match file {
-                    "test.wav" => Some(Color::Cyan),
-                    "test.rs" => Some(Color::Fixed(202)),
-                    _ => unreachable!(),
-                };
-                assert_eq!(color, style.foreground);
-            }
-        }
+
+        assert_eq!(lscolors.style_for_str(""), None);
+        assert_eq!(lscolors.style_for_str("test"), None);
+        assert_eq!(
+            lscolors.style_for_str("test.wav").unwrap().foreground,
+            Some(Color::Cyan)
+        );
+        assert_eq!(
+            lscolors.style_for_str("test.rs").unwrap().foreground,
+            Some(Color::Fixed(202))
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@ impl LsColors {
             // Note: using '.to_str()' here means that filename
             // matching will not work with invalid-UTF-8 paths.
             let filename = file.file_name();
-            return self.style_for_str(&filename.to_str()?);
+            return self.style_for_str(filename.to_str()?);
         }
 
         self.style_for_indicator(indicator)
@@ -425,7 +425,7 @@ impl LsColors {
             }
         }
         // It was not found
-        return None;
+        None
     }
 
     /// Get the ANSI style for a path, given the corresponding `Metadata` struct.


### PR DESCRIPTION
This pull request adds a function, `LsColors::style_for_str()` that retrieves the correct suffix style for any string.

It would provide a workaround for both #70 and #78, they would just have to verify that the file exists before colorizing it. Or, they could just colorize it, because that would work too.

It's pretty simple anyways. I decided not to implement this in `bin.rs` because I did not know if you want that or not.

Let me know if I need to revise anything. I tried to keep changes minimal, and this was literally the second rust `#[test]` I've ever written.