### PR TITLE
dep: update nu-ansi-term to latest release 0.50.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = [
     "linux",
     "terminal",
     "filesystem",
-    "color"
+    "color",
 ]
 license = "MIT/Apache-2.0"
 version = "0.16.0"
@@ -24,7 +24,7 @@ gnu_legacy = ["nu-ansi-term/gnu_legacy"]
 
 [dependencies]
 ansi_term = { version = "0.12", optional = true }
-nu-ansi-term = { version = "0.49", optional = true }
+nu-ansi-term = { version = "0.50", optional = true }
 crossterm = { version = "0.27", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR updates the nu-ansi-term dependency to 0.50.0, the version that was just released today (Jan 22).

Unfortunately, so many things depend on nu-ansi-term and lscolors that we get into a chicken-or-the-egg situation. Like right now, we can't compile nushell because we released this new version of nu-ansi-term and we depend on lscolors, which currently depends on nu-ansi-term 0.49.0. It would be great if we could get a `lscolors` release relatively soon @sharkdp.