### PR TITLE
Add owo-colors as an ansi backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ gnu_legacy = ["nu-ansi-term/gnu_legacy"]
 ansi_term = { version = "0.12", optional = true }
 nu-ansi-term = { version = "0.50", optional = true }
 crossterm = { version = "0.27", optional = true }
+owo-colors = { version = "4.0", optional = true }
 
 [dev-dependencies]
 tempfile = "^3"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -9,9 +9,12 @@ use lscolors::{LsColors, Style};
     not(feature = "nu-ansi-term"),
     not(feature = "gnu_legacy"),
     not(feature = "ansi_term"),
-    not(feature = "crossterm")
+    not(feature = "crossterm"),
+    not(feature = "owo-colors")
 ))]
-compile_error!("one feature must be enabled: ansi_term, nu-ansi-term, crossterm, gnu_legacy");
+compile_error!(
+    "one feature must be enabled: ansi_term, nu-ansi-term, crossterm, gnu_legacy, owo-colors"
+);
 
 fn print_path(handle: &mut dyn Write, ls_colors: &LsColors, path: &str) -> io::Result<()> {
     for (component, style) in ls_colors.style_for_path_components(Path::new(path)) {
@@ -31,6 +34,12 @@ fn print_path(handle: &mut dyn Write, ls_colors: &LsColors, path: &str) -> io::R
         {
             let ansi_style = style.map(Style::to_crossterm_style).unwrap_or_default();
             write!(handle, "{}", ansi_style.apply(component.to_string_lossy()))?;
+        }
+        #[cfg(feature = "owo-colors")]
+        {
+            use owo_colors::OwoColorize;
+            let ansi_style = style.map(Style::to_owo_colors_style).unwrap_or_default();
+            write!(handle, "{}", component.to_string_lossy().style(ansi_style))?;
         }
     }
     writeln!(handle)?;

--- a/src/style.rs
+++ b/src/style.rs
@@ -8,7 +8,7 @@ use std::collections::VecDeque;
 
 /// A `Color` can be one of the pre-defined ANSI colors (`Red`, `Green`, ..),
 /// a 8-bit ANSI color (`Fixed(u8)`) or a 24-bit color (`RGB(u8, u8, u8)`).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Color {
     Black,
     Red,
@@ -149,7 +149,7 @@ impl Color {
 }
 
 /// Font-style attributes.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct FontStyle {
     pub bold: bool,
     pub dimmed: bool, // a.k.a. faint
@@ -262,7 +262,7 @@ impl FontStyle {
 }
 
 /// A foreground color, background color and font-style.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Style {
     pub foreground: Option<Color>,
     pub background: Option<Color>,

--- a/src/style.rs
+++ b/src/style.rs
@@ -115,6 +115,37 @@ impl Color {
             Color::BrightWhite => crossterm::style::Color::White,
         }
     }
+
+    /// Convert to a `owo-colors::DynColors` (if the `owo-colors` feature is enabled).
+    #[cfg(feature = "owo-colors")]
+    pub fn to_owo_color(&self) -> owo_colors::DynColors {
+        match self {
+            Color::RGB(r, g, b) => owo_colors::DynColors::Rgb(*r, *g, *b),
+            Color::Fixed(n) => owo_colors::DynColors::Xterm(owo_colors::XtermColors::from(*n)),
+
+            Color::Black => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::Black),
+            Color::Red => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::Red),
+            Color::Green => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::Green),
+            Color::Yellow => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::Yellow),
+            Color::Blue => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::Blue),
+            Color::Magenta => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::Magenta),
+            Color::Cyan => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::Cyan),
+            Color::White => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::White),
+
+            Color::BrightBlack => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::BrightBlack),
+            Color::BrightRed => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::BrightRed),
+            Color::BrightGreen => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::BrightGreen),
+            Color::BrightYellow => {
+                owo_colors::DynColors::Ansi(owo_colors::AnsiColors::BrightYellow)
+            }
+            Color::BrightBlue => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::BrightBlue),
+            Color::BrightMagenta => {
+                owo_colors::DynColors::Ansi(owo_colors::AnsiColors::BrightMagenta)
+            }
+            Color::BrightCyan => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::BrightCyan),
+            Color::BrightWhite => owo_colors::DynColors::Ansi(owo_colors::AnsiColors::BrightWhite),
+        }
+    }
 }
 
 /// Font-style attributes.
@@ -473,6 +504,48 @@ impl Style {
             attributes: self.font_style.to_crossterm_attributes(),
             underline_color: self.underline.as_ref().map(Color::to_crossterm_color),
         }
+    }
+
+    /// Convert to a `owo_colors::Style` (if the `owo-colors` feature is enabled).
+    #[cfg(feature = "owo-colors")]
+    pub fn to_owo_colors_style(&self) -> owo_colors::Style {
+        let mut style = owo_colors::Style::new();
+        if let Some(ref c) = self.foreground {
+            style = style.color(c.to_owo_color())
+        }
+        if let Some(ref b) = self.background {
+            style = style.on_color(b.to_owo_color())
+        }
+        if self.font_style.bold {
+            style = style.bold()
+        }
+        if self.font_style.dimmed {
+            style = style.dimmed()
+        }
+        if self.font_style.hidden {
+            style = style.hidden()
+        }
+        if self.font_style.italic {
+            style = style.italic()
+        }
+        if self.font_style.rapid_blink {
+            style = style.blink_fast()
+        }
+        if self.font_style.reverse {
+            style = style.reversed()
+        }
+        if self.font_style.slow_blink {
+            style = style.blink()
+        }
+        if self.font_style.strikethrough {
+            style = style.strikethrough()
+        }
+        if self.font_style.underline {
+            style = style.underline()
+        }
+
+        // TODO: Implement colored underline. owo-colors does not support it at the time of writing.
+        style
     }
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -855,4 +855,20 @@ mod tests {
             cross.apply("wow").to_string()
         );
     }
+
+    #[cfg(all(feature = "owo-colors"))]
+    #[test]
+    fn coloring_owo_colors() {
+        use owo_colors::OwoColorize;
+        let style = Style {
+            font_style: FontStyle {
+                bold: true,
+                ..Default::default()
+            },
+            foreground: Some(Color::Blue),
+            ..Default::default()
+        };
+        let owo = style.to_owo_colors_style();
+        assert_eq!("\x1b[34;1mwow\x1b[0m", "wow".style(owo).to_string());
+    }
 }


### PR DESCRIPTION
Hey there, long time no see

I have been using owo-colors more in my projects, and I like it. It has been around for a while, touting itself as a minimal, no-std ansi color crate. This adds support for owo-colors as a backend.

The Style struct cannot be modified or created directly, so I had to mutate it based on the properties of `Style`. I also had to reverse the order of ansi codes in the owo-colors test because it prints those differently. However, I am pretty sure it should be OK.