### PR TITLE
Add zeroed_indicators to LsColors and make some functionalities public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,7 @@ pub struct LsColors {
     // Note: you might expect to see a `HashMap` for `suffix_mapping` as well, but we need to
     // preserve the exact order of the mapping in order to be consistent with `ls`.
     suffix_mapping: Vec<(FileNameSuffix, Option<Style>)>,
+    //Indicators that are passed with zero values
     pub zeroed_indicators: HashSet<Indicator>,
 }
 
@@ -476,6 +477,7 @@ impl LsColors {
         self.style_for(&PathWithMetadata { path, metadata })
     }
 
+    /// Returns the indicator for a path with corresponding metadata.
     pub fn indicator_for_path_with_metadata<P: AsRef<Path>>(
         &self,
         path: P,


### PR DESCRIPTION
hi, this pr is intended to solve this [issue](https://github.com/sharkdp/lscolors/issues/48#issuecomment-1582830387) by adding a field to `LsColors` that would record the zeroed indicators and making some functionalities public, so the user could use those to deal with zeroed indicators.